### PR TITLE
UI: Simplify Auto Config / Settings for Caffeine

### DIFF
--- a/UI/forms/AutoConfigStreamPage.ui
+++ b/UI/forms/AutoConfigStreamPage.ui
@@ -20,67 +20,20 @@
    <property name="labelAlignment">
     <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
    </property>
-   <item row="1" column="0">
-    <widget class="QLabel" name="serviceLabel">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Basic.AutoConfig.StreamPage.Service</string>
-     </property>
-     <property name="buddy">
-      <cstring>service</cstring>
+      <string>Basic.Settings.Stream.StreamType</string>
      </property>
     </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="streamType"/>
    </item>
    <item row="1" column="1">
-    <widget class="QComboBox" name="service"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="streamKeyLabel">
-     <property name="text">
-      <string>Basic.AutoConfig.StreamPage.StreamKey</string>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-     <property name="buddy">
-      <cstring>key</cstring>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout"/>
    </item>
    <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLineEdit" name="key">
-       <property name="inputMask">
-        <string notr="true"/>
-       </property>
-       <property name="text">
-        <string notr="true"/>
-       </property>
-       <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="show">
-       <property name="text">
-        <string>Show</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="6" column="1">
-    <widget class="QCheckBox" name="doBandwidthTest">
-     <property name="text">
-      <string>Basic.AutoConfig.StreamPage.PerformBandwidthTest</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
     <widget class="QCheckBox" name="preferHardware">
      <property name="toolTip">
       <string>Basic.AutoConfig.StreamPage.PreferHardwareEncoding.ToolTip</string>
@@ -93,7 +46,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="4" column="0">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -109,69 +62,17 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="serverLabel">
+   <item row="4" column="1">
+    <widget class="QCheckBox" name="doBandwidthTest">
      <property name="text">
-      <string>Basic.AutoConfig.StreamPage.Server</string>
+      <string>Basic.AutoConfig.StreamPage.PerformBandwidthTest</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Basic.Settings.Stream.StreamType</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="streamType"/>
-   </item>
-   <item row="2" column="1">
-    <widget class="QStackedWidget" name="serverStackedWidget">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="servicePage">
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QComboBox" name="server"/>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="customPage">
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLineEdit" name="customServer"/>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item row="7" column="1">
+   <item row="5" column="1">
     <widget class="QGroupBox" name="region">
      <property name="title">
       <string>BandwidthTest.Region</string>
@@ -208,7 +109,7 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="2" column="1">
     <widget class="QSpinBox" name="bitrate">
      <property name="suffix">
       <string notr="true"/>
@@ -224,7 +125,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="bitrateLabel">
      <property name="text">
       <string>Basic.Settings.Output.VideoBitrate</string>
@@ -238,11 +139,6 @@
  </widget>
  <tabstops>
   <tabstop>streamType</tabstop>
-  <tabstop>service</tabstop>
-  <tabstop>server</tabstop>
-  <tabstop>customServer</tabstop>
-  <tabstop>key</tabstop>
-  <tabstop>show</tabstop>
   <tabstop>preferHardware</tabstop>
   <tabstop>doBandwidthTest</tabstop>
   <tabstop>regionUS</tabstop>

--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -981,8 +981,7 @@ void AutoConfigTestPage::FinalizeResults()
 		obs_data_set_int(vencoder_settings, "bitrate",
 				wiz->idealBitrate);
 
-		obs_data_set_string(service_settings, "service",
-				wiz->serviceName.c_str());
+		obs_data_apply(service_settings, wiz->serviceSettings);
 		obs_service_update(service, service_settings);
 		obs_service_apply_encoder_settings(service,
 				vencoder_settings, nullptr);

--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -990,13 +990,16 @@ void AutoConfigTestPage::FinalizeResults()
 		wiz->idealBitrate = (int)obs_data_get_int(vencoder_settings,
 				"bitrate");
 
-		if (!wiz->customServer)
+		if (!wiz->customServer && !wiz->serviceName.empty())
 			form->addRow(
 				newLabel("Basic.AutoConfig.StreamPage.Service"),
 				new QLabel(wiz->serviceName.c_str(),
 					ui->finishPage));
-		form->addRow(newLabel("Basic.AutoConfig.StreamPage.Server"),
-			new QLabel(wiz->serverName.c_str(), ui->finishPage));
+		if(!wiz->serverName.empty())
+			form->addRow(
+				newLabel("Basic.AutoConfig.StreamPage.Server"),
+				new QLabel(wiz->serverName.c_str(),
+					ui->finishPage));
 		form->addRow(newLabel("Basic.Settings.Output.VideoBitrate"),
 			new QLabel(QString::number(wiz->idealBitrate),
 				ui->finishPage));

--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -1083,11 +1083,17 @@ void AutoConfigTestPage::NextStage()
 
 	} else if (stage == Stage::BandwidthTest) {
 		stage = Stage::StreamEncoder;
-		StartStreamEncoderStage();
+		if (wiz->skipStreamEncoder)
+			NextStage();
+		else
+			StartStreamEncoderStage();
 
 	} else if (stage == Stage::StreamEncoder) {
 		stage = Stage::RecordingEncoder;
-		StartRecordingEncoderStage();
+		if (wiz->skipRecordEncoder)
+			NextStage();
+		else
+			StartRecordingEncoderStage();
 
 	} else {
 		stage = Stage::Finished;

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -379,6 +379,7 @@ void AutoConfigStreamPage::StreamSettingsChanged(bool refreshPropertiesView)
 
 		streamPropertiesLayout->setSizeConstraint(QLayout::SetNoConstraint);
 		streamProperties->setSizePolicy(QSizePolicy::Policy::Minimum, QSizePolicy::Policy::MinimumExpanding);
+		streamProperties->setMinimumHeight(200);
 	}
 	const char* currentSettings = obs_data_get_json(serviceSettings);
 	blog(LOG_INFO, "%s", currentSettings);
@@ -456,6 +457,8 @@ AutoConfigStreamPage::AutoConfigStreamPage(QWidget *parent)
 
 	streamPropertiesLayout->setSizeConstraint(QLayout::SetNoConstraint);
 	streamProperties->setSizePolicy(QSizePolicy::Policy::Minimum, QSizePolicy::Policy::MinimumExpanding);
+
+	streamProperties->setMinimumHeight(200);
 
 	ui->bitrateLabel->setVisible(false);
 	ui->bitrate->setVisible(false);

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -286,8 +286,6 @@ void AutoConfigStreamPage::PropertiesChanged()
 	UpdateCompleted();
 }
 
-
-
 /* ------------------------------------------------------------------------- */
 
 AutoConfigStreamPage::AutoConfigStreamPage(QWidget *parent)
@@ -304,8 +302,7 @@ AutoConfigStreamPage::AutoConfigStreamPage(QWidget *parent)
 	serviceSettings = obs_service_get_settings(service);
 
 	streamProperties = new OBSPropertiesView(serviceSettings, service_type,
-		(PropertiesReloadCallback)obs_get_service_properties,
-		170);
+		(PropertiesReloadCallback)obs_get_service_properties, 0);
 	streamProperties->setProperty("changed", QVariant(false));
 
 	QObject::connect(streamProperties, SIGNAL(Changed()),
@@ -313,6 +310,9 @@ AutoConfigStreamPage::AutoConfigStreamPage(QWidget *parent)
 
 	streamPropertiesLayout->addWidget(streamProperties);
 	ui->formLayout->insertRow(1, streamPropertiesLayout);
+
+	streamPropertiesLayout->setSizeConstraint(QLayout::SetNoConstraint);
+	streamProperties->setSizePolicy(QSizePolicy::Policy::Minimum, QSizePolicy::Policy::MinimumExpanding);
 
 	ui->bitrateLabel->setVisible(false);
 	ui->bitrate->setVisible(false);

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -69,7 +69,9 @@ AutoConfigStartPage::~AutoConfigStartPage()
 
 int AutoConfigStartPage::nextId() const
 {
-	return AutoConfig::VideoPage;
+return wiz->type == AutoConfig::Type::Recording
+              ? AutoConfig::VideoPage
+              : AutoConfig::StreamPage;
 }
 
 void AutoConfigStartPage::on_prioritizeStreaming_clicked()
@@ -164,9 +166,7 @@ AutoConfigVideoPage::~AutoConfigVideoPage()
 
 int AutoConfigVideoPage::nextId() const
 {
-	return wiz->type == AutoConfig::Type::Recording
-		? AutoConfig::TestPage
-		: AutoConfig::StreamPage;
+	return AutoConfig::TestPage;
 }
 
 bool AutoConfigVideoPage::validatePage()
@@ -402,7 +402,7 @@ bool AutoConfigStreamPage::isComplete() const
 
 int AutoConfigStreamPage::nextId() const
 {
-	return AutoConfig::TestPage;
+	return AutoConfig::VideoPage;
 }
 
 bool AutoConfigStreamPage::validatePage()

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -438,44 +438,6 @@ bool AutoConfigStreamPage::validatePage()
 	return true;
 }
 
-void AutoConfigStreamPage::UpdateKeyLink()
-{
-	/*
-	bool custom = ui->streamType->currentIndex() == 1;
-	QString serviceName = ui->service->currentText();
-	bool isYoutube = false;
-
-	if (custom)
-		serviceName = "";
-
-	QString text = QTStr("Basic.AutoConfig.StreamPage.StreamKey");
-	if (serviceName == "Twitch") {
-		text += " <a href=\"https://";
-		text += "www.twitch.tv/broadcast/dashboard/streamkey";
-		text += "\">";
-		text += QTStr("Basic.AutoConfig.StreamPage.StreamKey.LinkToSite");
-		text += "</a>";
-	} else if (serviceName == "YouTube / YouTube Gaming") {
-		text += " <a href=\"https://";
-		text += "www.youtube.com/live_dashboard";
-		text += "\">";
-		text += QTStr("Basic.AutoConfig.StreamPage.StreamKey.LinkToSite");
-		text += "</a>";
-
-		isYoutube = true;
-	}
-
-	if (isYoutube) {
-		ui->doBandwidthTest->setChecked(false);
-		ui->doBandwidthTest->setEnabled(false);
-	} else {
-		ui->doBandwidthTest->setEnabled(true);
-	}
-
-	ui->streamKeyLabel->setText(text);
-	*/
-}
-
 void AutoConfigStreamPage::UpdateCompleted()
 {
 	QString key = obs_data_get_string(serviceSettings, "key");
@@ -486,7 +448,7 @@ void AutoConfigStreamPage::UpdateCompleted()
 		bool custom = qServiceType.toStdString().find("_custom") != std::string::npos;
 		if (custom) {
 			QString server = obs_data_get_string(serviceSettings, "server");
-			ready = !server.isEmpty();//!ui->customServer->text().isEmpty();
+			ready = !server.isEmpty();
 		} else {
 			ready = !wiz->testRegions ||
 				ui->regionUS->isChecked() ||

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -375,7 +375,7 @@ void AutoConfigStreamPage::StreamSettingsChanged(bool refreshPropertiesView)
 
 	bool custom = qServiceType.toStdString().find("_custom") != std::string::npos;
 
-	blog(LOG_INFO, "service: %s", qServiceType.toStdString().c_str());
+	blog(LOG_DEBUG, "service: %s", qServiceType.toStdString().c_str());
 
 	/* Reconstruct properties view */
 	if (refreshPropertiesView) {
@@ -402,7 +402,7 @@ void AutoConfigStreamPage::StreamSettingsChanged(bool refreshPropertiesView)
 	}
 
 	const char* currentSettings = obs_data_get_json(serviceSettings);
-	blog(LOG_INFO, "%s", currentSettings);
+	blog(LOG_DEBUG, "%s", currentSettings);
 
 	UpdateBandwidthTest();
 	UpdateBitrate();
@@ -555,15 +555,15 @@ bool AutoConfigStreamPage::validatePage()
 
 	std::string qServiceTypeName = ui->streamType->currentText().toStdString();
 
-	blog(LOG_INFO, "type: %s", qServiceType.c_str());
-	blog(LOG_INFO, "name: %s", qServiceTypeName.c_str());
+	blog(LOG_DEBUG, "type: %s", qServiceType.c_str());
+	blog(LOG_DEBUG, "name: %s", qServiceTypeName.c_str());
 
 	wiz->customServer = qServiceType.find("_custom") != std::string::npos;
 
 	const char *serverType = qServiceType.c_str();
 
 	const char *json_settings = obs_data_get_json(serviceSettings);
-	blog(LOG_INFO, "test_settings: %s", json_settings);
+	blog(LOG_DEBUG, "test_settings: %s", json_settings);
 
 	if (!wiz->customServer) {
 		obs_data_set_string(service_settings, "service",
@@ -592,8 +592,8 @@ bool AutoConfigStreamPage::validatePage()
 	std::string server = obs_data_get_string(serviceSettings, "server");
 	wiz->server = server;
 
-	blog(LOG_INFO, "name: %s", wiz->serverName.c_str());
-	blog(LOG_INFO, "addr: %s", wiz->server.c_str());
+	blog(LOG_DEBUG, "name: %s", wiz->serverName.c_str());
+	blog(LOG_DEBUG, "addr: %s", wiz->server.c_str());
 
 	if (wiz->customServer)
 		wiz->serverName = wiz->server;
@@ -647,7 +647,7 @@ static bool validateRequirements(obs_data_t *settings)
 	obs_data_item_t *item;
 	obs_data_item_t *test_item;
 	const char *json_settings = obs_data_get_json(settings);
-	blog(LOG_INFO, "%s", json_settings);
+	blog(LOG_DEBUG, "%s", json_settings);
 
 	for (item = obs_data_first(settings); item; obs_data_item_next(&item)) {
 		obs_data_type item_type = obs_data_item_gettype(item);
@@ -674,11 +674,11 @@ static bool validateRequirements(obs_data_t *settings)
 		test_item = obs_data_item_byname(settings, name);
 
 		if (!obs_data_item_has_user_value(test_item)) {
-			blog(LOG_INFO, "%s not found", name);
+			blog(LOG_DEBUG, "%s not found", name);
 			obs_data_item_release(&test_item);
 			return false;
 		}
-		blog(LOG_INFO, "%s found", name);
+		blog(LOG_DEBUG, "%s found", name);
 		obs_data_item_release(&test_item);
 		return true;
 	} else if (type == OBS_DATA_OBJECT) {
@@ -689,23 +689,23 @@ static bool validateRequirements(obs_data_t *settings)
 
 	requirementsObj = obs_data_get_obj(settings, "requirements");
 	const char *json = obs_data_get_json(requirementsObj);
-	blog(LOG_INFO, "%s", json);
+	blog(LOG_DEBUG, "%s", json);
 	for (item = obs_data_first(requirementsObj); item; obs_data_item_next(&item)) {
 		enum obs_data_type type = obs_data_item_gettype(item);
 		const char *name = obs_data_item_get_name(item);
-		blog(LOG_INFO, "%s required", name);
+		blog(LOG_DEBUG, "%s required", name);
 		if (!obs_data_item_has_user_value(item))
 			return false;
 
 		test_item = obs_data_item_byname(settings, name);
 
 		if (!obs_data_item_has_user_value(test_item)) {
-			blog(LOG_INFO, "%s not found", name);
+			blog(LOG_DEBUG, "%s not found", name);
 			obs_data_item_release(&test_item);
 			return false;
 		}
 		obs_data_item_release(&test_item);
-		blog(LOG_INFO, "%s found", name);
+		blog(LOG_DEBUG, "%s found", name);
 	}
 
 	return true;

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -369,19 +369,24 @@ void AutoConfigStreamPage::StreamSettingsChanged(bool refreshPropertiesView)
 		obs_data_apply(serviceSettings, defaults);
 		obs_data_release(defaults);
 
-		streamPropertiesLayout->removeWidget(streamProperties);
+		//streamPropertiesLayout->removeWidget(streamProperties);
 		streamProperties->deleteLater();
 		streamProperties = new OBSPropertiesView(serviceSettings, qServiceType.toStdString().c_str(),
 			(PropertiesReloadCallback)obs_get_service_properties, 0);
 		streamProperties->setProperty("changed", QVariant(false));
+		streamProperties->setFrameShape(QFrame::StyledPanel);
+		streamProperties->setWidgetResizable(true);
 
 		QObject::connect(streamProperties, SIGNAL(Changed()),
 			this, SLOT(PropertiesChanged()));
-		streamPropertiesLayout->addWidget(streamProperties);
+		//streamPropertiesLayout->addWidget(streamProperties);
+		ui->formLayout->insertRow(1, streamProperties);
 
-		streamPropertiesLayout->setSizeConstraint(QLayout::SetNoConstraint);
-		streamProperties->setSizePolicy(QSizePolicy::Policy::Minimum, QSizePolicy::Policy::MinimumExpanding);
-		streamProperties->setMinimumHeight(200);
+		//streamPropertiesLayout->setSizeConstraint(QLayout::SetNoConstraint);
+		streamProperties->setSizePolicy(QSizePolicy::Policy::MinimumExpanding, QSizePolicy::Policy::MinimumExpanding);
+		//streamProperties->setMinimumHeight(200);
+		//QRect area = streamProperties->childrenRect();
+		//streamProperties->setMinimumHeight(area.height());
 	}
 	const char* currentSettings = obs_data_get_json(serviceSettings);
 	blog(LOG_INFO, "%s", currentSettings);
@@ -440,7 +445,8 @@ AutoConfigStreamPage::AutoConfigStreamPage(QWidget *parent)
 {
 	ui->setupUi(this);
 
-	streamPropertiesLayout = new QVBoxLayout(this);
+	//streamPropertiesLayout = new QVBoxLayout(this);
+	ui->formLayout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 
 	obs_service_t *service = static_cast<OBSBasic*>(QApplication::activeWindow())->GetService();
 	const char *service_type = obs_service_get_type(service);
@@ -450,17 +456,21 @@ AutoConfigStreamPage::AutoConfigStreamPage(QWidget *parent)
 	streamProperties = new OBSPropertiesView(serviceSettings, service_type,
 		(PropertiesReloadCallback)obs_get_service_properties, 0);
 	streamProperties->setProperty("changed", QVariant(false));
+	streamProperties->setFrameShape(QFrame::StyledPanel);
+	streamProperties->setWidgetResizable(true);
 
 	QObject::connect(streamProperties, SIGNAL(Changed()),
 			this, SLOT(PropertiesChanged()));
 
-	streamPropertiesLayout->addWidget(streamProperties);
-	ui->formLayout->insertRow(1, streamPropertiesLayout);
+	//streamPropertiesLayout->addWidget(streamProperties);
+	//ui->formLayout->insertRow(1, streamPropertiesLayout);
+	ui->formLayout->insertRow(1, streamProperties);
 
-	streamPropertiesLayout->setSizeConstraint(QLayout::SetNoConstraint);
-	streamProperties->setSizePolicy(QSizePolicy::Policy::Minimum, QSizePolicy::Policy::MinimumExpanding);
-
-	streamProperties->setMinimumHeight(200);
+	//streamPropertiesLayout->setSizeConstraint(QLayout::SetNoConstraint);
+	streamProperties->setSizePolicy(QSizePolicy::Policy::MinimumExpanding, QSizePolicy::Policy::MinimumExpanding);
+	//QRect area = streamProperties->childrenRect();
+	//streamProperties->setMinimumHeight(area.height());
+	//streamProperties->setMinimumHeight(200);
 
 	ui->bitrateLabel->setVisible(false);
 	ui->bitrate->setVisible(false);
@@ -486,15 +496,15 @@ AutoConfigStreamPage::AutoConfigStreamPage(QWidget *parent)
 		this, SLOT(SettingsChanged()));
 
 	connect(ui->doBandwidthTest, SIGNAL(toggled(bool)),
-		this, SLOT(SettingsChanged()));
+		this, SLOT(PropertiesChanged()));
 	connect(ui->regionUS, SIGNAL(toggled(bool)),
-		this, SLOT(SettingsChanged()));
+		this, SLOT(PropertiesChanged()));
 	connect(ui->regionEU, SIGNAL(toggled(bool)),
-		this, SLOT(SettingsChanged()));
+		this, SLOT(PropertiesChanged()));
 	connect(ui->regionAsia, SIGNAL(toggled(bool)),
-		this, SLOT(SettingsChanged()));
+		this, SLOT(PropertiesChanged()));
 	connect(ui->regionOther, SIGNAL(toggled(bool)),
-		this, SLOT(SettingsChanged()));
+		this, SLOT(PropertiesChanged()));
 }
 
 AutoConfigStreamPage::~AutoConfigStreamPage()

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -212,7 +212,9 @@ AutoConfigVideoPage::AutoConfigVideoPage(QWidget *parent)
 		QString str = QString("%1x%2").arg(
 				QString::number(cx),
 				QString::number(cy));
-		ui->canvasRes->addItem(str, encRes);
+		int idx = ui->canvasRes->findData(encRes);
+		if (idx < 0)
+			ui->canvasRes->addItem(str, encRes);
 	};
 
 	addRes(1920, 1080);

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -178,6 +178,8 @@ public:
 public slots:
 	void UpdateKeyLink();
 	void UpdateCompleted();
+	void StreamSettingsChanged(bool refreshPropertiesView);
+	void SettingsChanged();
 	void PropertiesChanged();
 };
 

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -176,7 +176,6 @@ public:
 	virtual bool validatePage() override;
 
 public slots:
-	void UpdateKeyLink();
 	void UpdateCompleted();
 	void StreamSettingsChanged(bool refreshPropertiesView);
 	void SettingsChanged();

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -177,6 +177,7 @@ public:
 
 public slots:
 	void UpdateCompleted();
+	void UpdateBandwidthTest();
 	void StreamSettingsChanged(bool refreshPropertiesView);
 	void SettingsChanged();
 	void PropertiesChanged();

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -161,7 +161,6 @@ class AutoConfigStreamPage : public QWizardPage {
 	QString lastService;
 	bool ready = false;
 
-	void LoadServices(bool showAll);
 	OBSPropertiesView *streamProperties = nullptr;
 	OBSData serviceSettings;
 	QVBoxLayout *streamPropertiesLayout = nullptr;
@@ -175,10 +174,8 @@ public:
 	virtual bool validatePage() override;
 
 public slots:
-	void on_show_clicked();
 	void ServiceChanged();
 	void UpdateKeyLink();
-	void UpdateServerList();
 	void UpdateCompleted();
 	void PropertiesChanged();
 };

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -88,6 +88,9 @@ class AutoConfig : public QWizard {
 	bool qsvAvailable = false;
 	bool vceAvailable = false;
 
+	bool skipStreamEncoder = false;
+	bool skipRecordEncoder = false;
+
 	int startingBitrate = 2500;
 	bool customServer = false;
 	bool bandwidthTest = false;
@@ -185,6 +188,7 @@ public slots:
 	void UpdateCompleted();
 	void UpdateBandwidthTest();
 	void UpdateBitrate();
+	void UpdatePreferHardware();
 	void StreamSettingsChanged(bool refreshPropertiesView);
 	void SettingsChanged();
 	void PropertiesChanged();

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <mutex>
 
+#include "properties-view.hpp"
+
 class Ui_AutoConfigStartPage;
 class Ui_AutoConfigVideoPage;
 class Ui_AutoConfigStreamPage;
@@ -160,6 +162,9 @@ class AutoConfigStreamPage : public QWizardPage {
 	bool ready = false;
 
 	void LoadServices(bool showAll);
+	OBSPropertiesView *streamProperties = nullptr;
+	OBSData serviceSettings;
+	QVBoxLayout *streamPropertiesLayout = nullptr;
 
 public:
 	AutoConfigStreamPage(QWidget *parent = nullptr);
@@ -175,6 +180,7 @@ public slots:
 	void UpdateKeyLink();
 	void UpdateServerList();
 	void UpdateCompleted();
+	void PropertiesChanged();
 };
 
 class AutoConfigTestPage : public QWizardPage {

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -176,7 +176,6 @@ public:
 	virtual bool validatePage() override;
 
 public slots:
-	void ServiceChanged();
 	void UpdateKeyLink();
 	void UpdateCompleted();
 	void PropertiesChanged();

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -75,10 +75,12 @@ class AutoConfig : public QWizard {
 	int idealResolutionCY = 720;
 	int idealFPSNum = 60;
 	int idealFPSDen = 1;
+	std::string serviceType;
 	std::string serviceName;
 	std::string serverName;
 	std::string server;
 	std::string key;
+	OBSData serviceSettings;
 
 	bool hardwareEncodingAvailable = false;
 	bool nvencAvailable = false;

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -57,7 +57,8 @@ class AutoConfig : public QWizard {
 		PreferHighRes,
 		UseCurrent,
 		fps30,
-		fps60
+		fps60,
+		ServiceSpecified
 	};
 
 	static inline const char *GetEncoderId(Encoder enc);
@@ -100,6 +101,8 @@ class AutoConfig : public QWizard {
 	bool preferHardware = false;
 	int specificFPSNum = 0;
 	int specificFPSDen = 0;
+
+	bool serviceSpecifiedFPS = false;
 
 	void TestHardwareEncoding();
 	bool CanTestServer(const char *server);
@@ -152,6 +155,9 @@ public:
 
 	virtual int nextId() const override;
 	virtual bool validatePage() override;
+	virtual void initializePage() override;
+public slots:
+	void SettingsChanged();
 };
 
 class AutoConfigStreamPage : public QWizardPage {
@@ -178,6 +184,7 @@ public:
 public slots:
 	void UpdateCompleted();
 	void UpdateBandwidthTest();
+	void UpdateBitrate();
 	void StreamSettingsChanged(bool refreshPropertiesView);
 	void SettingsChanged();
 	void PropertiesChanged();

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -171,6 +171,7 @@ class AutoConfigStreamPage : public QWizardPage {
 	Ui_AutoConfigStreamPage *ui;
 	QString lastService;
 	bool ready = false;
+	bool firstRun = true;
 
 	OBSPropertiesView *streamProperties = nullptr;
 	OBSData serviceSettings;
@@ -180,6 +181,7 @@ public:
 	AutoConfigStreamPage(QWidget *parent = nullptr);
 	~AutoConfigStreamPage();
 
+	virtual void initializePage() override;
 	virtual bool isComplete() const override;
 	virtual int nextId() const override;
 	virtual bool validatePage() override;

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -187,6 +187,7 @@ public:
 	virtual bool validatePage() override;
 
 public slots:
+	void reAdjustSize();
 	void UpdateCompleted();
 	void UpdateBandwidthTest();
 	void UpdateBitrate();

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1321,7 +1321,32 @@ void OBSBasicSettings::ResetDownscales(uint32_t cx, uint32_t cy)
 		}
 	}
 
-	string res = ResString(cx, cy);
+	obs_output_t *output = nullptr;
+	OBSBasic *main = qobject_cast<OBSBasic*>(parent());
+	if (main && main->outputHandler)
+		output = main->outputHandler->streamOutput;
+
+	struct resolution {
+		uint32_t cx;
+		uint32_t cy;
+	};
+	DARRAY(resolution) scaled_resolutions;
+	darray *output_resolutions = obs_output_get_scaled_resolutions(output,
+		cx, cy);
+	if (output_resolutions) {
+		scaled_resolutions.da = *output_resolutions;
+		for (size_t i = 0; i < scaled_resolutions.num; i++) {
+			std::string recommendedRes = ResString(scaled_resolutions.array[i].cx,
+				scaled_resolutions.array[i].cy);
+			if (ui->advOutRescale->findData(recommendedRes.c_str()) < 0) {
+				ui->advOutRescale->addItem(recommendedRes.c_str());
+				ui->advOutRecRescale->addItem(recommendedRes.c_str());
+				ui->advOutFFRescale->addItem(recommendedRes.c_str());
+			}
+		}
+	}
+
+	std::string res = ResString(cx, cy);
 
 	float baseAspect   = float(cx) / float(cy);
 	float outputAspect = float(out_cx) / float(out_cy);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1258,6 +1258,18 @@ void OBSBasicSettings::ResetDownscales(uint32_t cx, uint32_t cy)
 			QString::number(out_cy);
 	}
 
+	auto getFixedHeight = [](uint32_t cx, uint32_t cy, uint32_t fx) {
+		double aspect = (double(cx) / double(cy));
+		uint32_t fy = fx * aspect;
+		return ResString(fx, fy);
+	};
+
+	auto getFixedWidth = [](uint32_t cx, uint32_t cy, uint32_t fy) {
+		double inv_aspect = (double(cy) / double(cx));
+		uint32_t fx = fy * inv_aspect;
+		return ResString(fx, fy);
+	};
+
 	for (size_t idx = 0; idx < numVals; idx++) {
 		uint32_t downscaleCX = uint32_t(double(cx) / vals[idx]);
 		uint32_t downscaleCY = uint32_t(double(cy) / vals[idx]);
@@ -1285,6 +1297,27 @@ void OBSBasicSettings::ResetDownscales(uint32_t cx, uint32_t cy)
 		if (diff < bestPixelDiff) {
 			bestScale = res;
 			bestPixelDiff = diff;
+		}
+	}
+
+	std::vector<int> fixedHeights = { 480, 720, 1080 };
+	std::vector<int> fixedWidths = { 640, 1280, 1920 };
+
+	for (size_t i = 0; i < fixedHeights.size(); i++) {
+		std::string fixedHRes = getFixedHeight(cx, cy, fixedHeights[i]);
+		if (ui->advOutRescale->findData(fixedHRes.c_str()) < 0) {
+			ui->advOutRescale->addItem(fixedHRes.c_str());
+			ui->advOutRecRescale->addItem(fixedHRes.c_str());
+			ui->advOutFFRescale->addItem(fixedHRes.c_str());
+		}
+	}
+
+	for (size_t i = 0; i < fixedWidths.size(); i++) {
+		std::string fixedWRes = getFixedWidth(cx, cy, fixedWidths[i]);
+		if (ui->advOutRescale->findData(fixedWRes.c_str()) < 0) {
+			ui->advOutRescale->addItem(fixedWRes.c_str());
+			ui->advOutRecRescale->addItem(fixedWRes.c_str());
+			ui->advOutFFRescale->addItem(fixedWRes.c_str());
 		}
 	}
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -279,6 +279,16 @@ bool obs_output_start(obs_output_t *output)
 	}
 }
 
+struct darray *obs_output_get_scaled_resolutions(const obs_output_t *output,
+		uint32_t cx, uint32_t cy)
+{
+	if (!obs_output_valid(output, "obs_output_get_scaled_resolutions"))
+		return NULL;
+	if (output->info.get_scaled_resolutions)
+		return output->info.get_scaled_resolutions(cx, cy);
+	return NULL;
+}
+
 static inline bool data_active(struct obs_output *output)
 {
 	return os_atomic_load_bool(&output->data_active);

--- a/libobs/obs-output.h
+++ b/libobs/obs-output.h
@@ -76,6 +76,9 @@ struct obs_output_info {
 	void (*raw_audio2)(void *data, size_t idx, struct audio_data *frames);
 
 	char const * (*get_username)(void *data);
+
+	/* callback to get recommended resolutions given a base resolution */
+	struct darray* (*get_scaled_resolutions)(uint32_t cx, uint32_t cy);
 };
 
 EXPORT void obs_register_output_s(const struct obs_output_info *info,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1729,6 +1729,9 @@ EXPORT const char *obs_output_get_supported_video_codecs(
 EXPORT const char *obs_output_get_supported_audio_codecs(
 		const obs_output_t *output);
 
+EXPORT struct darray *obs_output_get_scaled_resolutions(const obs_output_t *output,
+		uint32_t cx, uint32_t cy);
+
 /* ------------------------------------------------------------------------- */
 /* Functions used by outputs */
 

--- a/plugins/caffeine/caffeine-output.c
+++ b/plugins/caffeine/caffeine-output.c
@@ -17,6 +17,7 @@
 #include "caffeine-api.h"
 #include "caffeine-foreground-process.h"
 #include "caffeine-service.h"
+#include "util/darray.h"
 
 #define CAFFEINE_LOG_TITLE "caffeine output"
 #include "caffeine-log.h"
@@ -1091,6 +1092,30 @@ static void caffeine_destroy(void *data)
 	bfree(data);
 }
 
+static struct resolution {
+	uint32_t cx;
+	uint32_t cy;
+};
+
+static struct darray *caffeine_scaled_resolutions(uint32_t cx, uint32_t cy)
+{
+	struct darray *d = bmalloc(sizeof(struct darray));
+	darray_init(d);
+	if (cy > 720) {
+		double aspect = (double)cx / (double)cy;
+		struct resolution res;
+		res.cy = 720;
+		res.cx = aspect * 720;
+		darray_push_back(sizeof(struct resolution), d, &res);
+	} else {
+		struct resolution res;
+		res.cy = cy;
+		res.cx = cx;
+		darray_push_back(sizeof(struct resolution), d, &res);
+	}
+	return d;
+}
+
 static float caffeine_get_congestion(void * data)
 {
 	struct caffeine_output * context = data;
@@ -1135,4 +1160,5 @@ struct obs_output_info caffeine_output_info = {
 	.destroy   = caffeine_destroy,
 	.get_congestion = caffeine_get_congestion,
 	.get_username = caffeine_get_username,
+	.get_scaled_resolutions = caffeine_scaled_resolutions,
 };

--- a/plugins/caffeine/caffeine-output.c
+++ b/plugins/caffeine/caffeine-output.c
@@ -1101,17 +1101,27 @@ static struct darray *caffeine_scaled_resolutions(uint32_t cx, uint32_t cy)
 {
 	struct darray *d = bmalloc(sizeof(struct darray));
 	darray_init(d);
-	if (cy > 720) {
-		double aspect = (double)cx / (double)cy;
-		struct resolution res;
-		res.cy = 720;
-		res.cx = aspect * 720;
-		darray_push_back(sizeof(struct resolution), d, &res);
-	} else {
-		struct resolution res;
-		res.cy = cy;
-		res.cx = cx;
-		darray_push_back(sizeof(struct resolution), d, &res);
+	double aspect = 1.0;
+	if(cy > 0)
+		aspect = (double)cx / (double)cy;
+
+	struct resolution res;
+	res.cy = cy;
+	res.cx = cx;
+	darray_push_back(sizeof(struct resolution), d, &res);
+	/* Upscales of 720 */
+	for (int i = 3; i > 0; i--) {
+		res.cy = (720 * i);
+		res.cx = aspect * (720 * i);
+		if(cy >= res.cy)
+			darray_push_back(sizeof(struct resolution), d, &res);
+	}
+	/* Downscales of 720 */
+	for (int i = 2; i < 5; i+=2) {
+		res.cy = (720 / i);
+		res.cx = aspect * (720 / i);
+		if (cy >= res.cy)
+			darray_push_back(sizeof(struct resolution), d, &res);
 	}
 	return d;
 }

--- a/plugins/caffeine/caffeine-service.c
+++ b/plugins/caffeine/caffeine-service.c
@@ -65,7 +65,15 @@ static void set_requirements(obs_data_t *settings)
 	obs_data_set_obj(settings, "requirements", requirements);
 	obs_data_release(requirements);
 
+	obs_data_t *output_settings = obs_data_create();
+	obs_data_set_int(output_settings, "output_fps_num", 30);
+	obs_data_set_int(output_settings, "output_fps_den", 1);
+	obs_data_set_bool(output_settings, "output_prefer_high_fps", false);
+	obs_data_set_obj(settings, "output_settings", output_settings);
+	obs_data_release(output_settings);
+
 	obs_data_set_bool(settings, "disable_bandwidth_test", true);
+	obs_data_set_bool(settings, "disable_bitrate_setting", true);
 }
 
 static void caffeine_service_update(void * data, obs_data_t * settings)

--- a/plugins/caffeine/caffeine-service.c
+++ b/plugins/caffeine/caffeine-service.c
@@ -73,7 +73,10 @@ static void set_requirements(obs_data_t *settings)
 	obs_data_release(output_settings);
 
 	obs_data_set_bool(settings, "disable_bandwidth_test", true);
-	obs_data_set_bool(settings, "disable_bitrate_setting", true);
+	obs_data_set_bool(settings, "disable_bitrate_option", true);
+	obs_data_set_bool(settings, "disable_prefer_hardware", true);
+	obs_data_set_bool(settings, "disable_stream_local_testing", true);
+	obs_data_set_bool(settings, "disable_record_local_testing", true);
 }
 
 static void caffeine_service_update(void * data, obs_data_t * settings)

--- a/plugins/caffeine/caffeine-service.c
+++ b/plugins/caffeine/caffeine-service.c
@@ -64,6 +64,8 @@ static void set_requirements(obs_data_t *settings)
 //	obs_data_set_bool(requirements, BROADCAST_RATING_KEY, true);
 	obs_data_set_obj(settings, "requirements", requirements);
 	obs_data_release(requirements);
+
+	obs_data_set_bool(settings, "disable_bandwidth_test", true);
 }
 
 static void caffeine_service_update(void * data, obs_data_t * settings)

--- a/plugins/caffeine/caffeine-service.c
+++ b/plugins/caffeine/caffeine-service.c
@@ -56,6 +56,16 @@ static void caffeine_service_free_contents(struct caffeine_service * context)
 	context->broadcast_rating = CAFF_RATING_NONE;
 }
 
+static void set_requirements(obs_data_t *settings)
+{
+	obs_data_t *requirements = obs_data_create();
+	obs_data_set_bool(requirements, REFRESH_TOKEN_KEY, true);
+	obs_data_set_bool(requirements, BROADCAST_TITLE_KEY, true);
+//	obs_data_set_bool(requirements, BROADCAST_RATING_KEY, true);
+	obs_data_set_obj(settings, "requirements", requirements);
+	obs_data_release(requirements);
+}
+
 static void caffeine_service_update(void * data, obs_data_t * settings)
 {
 	trace();
@@ -70,6 +80,8 @@ static void caffeine_service_update(void * data, obs_data_t * settings)
 		bstrdup(obs_data_get_string(settings, BROADCAST_TITLE_KEY));
 	context->broadcast_rating =
 		obs_data_get_int(settings, BROADCAST_RATING_KEY);
+
+	set_requirements(settings);
 }
 
 static void * caffeine_service_create(
@@ -152,6 +164,8 @@ static bool signin_clicked(obs_properties_t * props, obs_property_t * prop,
 	UNUSED_PARAMETER(prop);
 	UNUSED_PARAMETER(data);
 
+	set_requirements(settings);
+
 	char const * username = obs_data_get_string(settings, USERNAME_KEY);
 	char const * password = obs_data_get_string(settings, PASSWORD_KEY);
 
@@ -221,6 +235,8 @@ static bool signout_clicked(obs_properties_t * props, obs_property_t * prop,
 	trace();
 	UNUSED_PARAMETER(prop);
 	UNUSED_PARAMETER(data);
+
+	set_requirements(settings);
 
 	obs_data_erase(settings, REFRESH_TOKEN_KEY);
 	obs_data_erase(settings, USERNAME_KEY);
@@ -302,6 +318,7 @@ static void caffeine_service_defaults(obs_data_t *defaults)
 	trace();
 	obs_data_set_default_string(defaults, BROADCAST_TITLE_KEY,
 		obs_module_text("DefaultBroadcastTitle"));
+	set_requirements(defaults);
 }
 
 static bool caffeine_service_initialize(void * data, obs_output_t * output)


### PR DESCRIPTION
Edits the auto configuration wizard to take some additional settings from the plugin.

Note: Does make use of changes to libobs, and uses the properties view. The properties view is being
removed for services in regular OBS, so these edits will be moot in the near future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/obs-studio/14)
<!-- Reviewable:end -->
