### PR TITLE
caffeine: Fix timestamp underflow

### DIFF
--- a/plugins/caffeine/caffeine-output.c
+++ b/plugins/caffeine/caffeine-output.c
@@ -331,7 +331,7 @@ static void caffeine_raw_video(void *data, struct video_data *frame)
 	size_t total_bytes = frame->linesize[0] * height;
 	caff_VideoFormat format =
 		obs_to_caffeine_format(context->video_info.output_format);
-	int32_t timestampMicros = frame->timestamp / 1000;
+	int64_t timestampMicros = frame->timestamp / 1000;
 
 	if (!context->start_timestamp)
 		context->start_timestamp = frame->timestamp;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/obs-studio/32)
<!-- Reviewable:end -->
