### PR TITLE
CI,cmake: Build with Caffeine for macOS

### DIFF
--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -35,8 +35,11 @@ ccache -s || echo "CCache is not available."
 
 # Fetch and untar prebuilt OBS deps that are compatible with older versions of OSX
 hr "Downloading OBS deps"
-wget --quiet --retry-connrefused --waitretry=1 https://obs-nightly.s3.amazonaws.com/osx-deps-2018-08-09.tar.gz
-tar -xf ./osx-deps-2018-08-09.tar.gz -C /tmp
+#TODO: Revert this once libcaffeine is included in deps
+#wget --quiet --retry-connrefused --waitretry=1 https://obs-nightly.s3.amazonaws.com/osx-deps-2018-08-09.tar.gz
+#tar -xf ./osx-deps-2018-08-09.tar.gz -C /tmp
+wget --quiet --retry-connrefused --waitretry=1 https://static.caffeine.tv/broadcaster/osx-deps-caffeine-2019-06-04.tar.gz
+tar -xf ./osx-deps-caffeine-2019-06-04.tar.gz -C /tmp
 
 # Fetch vlc codebase
 hr "Downloading VLC repo"

--- a/plugins/caffeine/CMakeLists.txt
+++ b/plugins/caffeine/CMakeLists.txt
@@ -30,6 +30,12 @@ target_link_libraries(caffeine
 
 install_obs_plugin_with_data(caffeine data)
 
-# TODO: figure out how to get libcaffeine copied to the right place on Mac & Linux
-# TODO: this sort of works on mac, but CI script fails. It doesn't do the right thing on linux
-#install_obs_bin(caffeine "" ${CAFFEINE_SHARED})
+# TODO: There may be a better way to do this, but generator expression didn't
+# work with the install_obs_bin helper
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(copy_bin ${LIBCAFFEINE_BINARY_DEBUG})
+else()
+    set(copy_bin ${LIBCAFFEINE_BINARY_RELWITHDEBINFO})
+endif()
+
+install_obs_bin(caffeine "" ${copy_bin})


### PR DESCRIPTION
Also fixes the need to manually copy the dylib into the bin dir

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/obs-studio/47)
<!-- Reviewable:end -->
