### PR TITLE
Don't set title on info panel's caffeine instance

### DIFF
--- a/UI/window-caffeine.cpp
+++ b/UI/window-caffeine.cpp
@@ -26,9 +26,6 @@ void CaffeineInfoPanel::updateClicked(bool)
 		obs_service_update(service, data);
 		obs_data_release(data);
 	}
-
-	caff_setTitle(caffeineInstance, title.c_str());
-	caff_setRating(caffeineInstance, rating);
 }
 
 void CaffeineInfoPanel::viewOnWebClicked(bool)


### PR DESCRIPTION
It doesn't do anything except emit a log about not having an active broadcast since it's not the broadcasting instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/obs-studio/58)
<!-- Reviewable:end -->
