### PR TITLE
COBS-62 Help link in COBS should link to caffeine help center

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5960,7 +5960,7 @@ void OBSBasic::on_settingsButton_clicked()
 
 void OBSBasic::on_actionHelpPortal_triggered()
 {
-	QUrl url = QUrl("https://obsproject.com/help", QUrl::TolerantMode);
+	QUrl url = QUrl("https://caffeine.custhelp.com", QUrl::TolerantMode);
 	QDesktopServices::openUrl(url);
 }
 


### PR DESCRIPTION
Changed the help link to point to caffeine help center

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/obs-studio/68)
<!-- Reviewable:end -->
