### PR TITLE
Fixed cmake handling of backslashes in Windows

### DIFF
--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -23,7 +23,7 @@ if(INSTALLER_RUN AND NOT DEFINED ENV{obsInstallerTempDir})
 endif()
 
 if(DEFINED ENV{obsInstallerTempDir})
-	file(TO_CMAKE_PATH "$ENV{obsInstallerTempDir}" ENV{obsInstallerTempDir})
+	file(TO_CMAKE_PATH "$ENV{obsInstallerTempDir}" obsInstallerTempDir)
 endif()
 
 if(DEFINED ENV{obsAdditionalInstallFiles})
@@ -33,7 +33,7 @@ else()
 endif()
 
 list(APPEND CMAKE_INCLUDE_PATH
-	"$ENV{obsAdditionalInstallFiles}/include${_lib_suffix}"
+	"$ENV{obsAdditionalInstallFiles}/include${_lib_suffix}"	
 	"$ENV{obsAdditionalInstallFiles}/include")
 
 list(APPEND CMAKE_LIBRARY_PATH
@@ -123,7 +123,7 @@ function(obs_finish_bundle)
 endfunction()
 
 function(obs_generate_multiarch_installer)
-	install(DIRECTORY "$ENV{obsInstallerTempDir}/"
+	install(DIRECTORY "${obsInstallerTempDir}/"
 		DESTINATION "."
 		USE_SOURCE_PERMISSIONS)
 endfunction()
@@ -358,8 +358,8 @@ function(install_obs_pdb ttype target)
 	if("${ttype}" STREQUAL "PLUGIN")
 		obs_debug_copy_helper(${target} "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/obs-plugins/${_bit_suffix}")
 
-		if(DEFINED ENV{obsInstallerTempDir})
-			obs_debug_copy_helper(${target} "$ENV{obsInstallerTempDir}/${OBS_PLUGIN_DESTINATION}")
+		if(DEFINED ${obsInstallerTempDir})
+			obs_debug_copy_helper(${target} "${obsInstallerTempDir}/${OBS_PLUGIN_DESTINATION}")
 		endif()
 
 		install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/pdbs/"
@@ -368,8 +368,8 @@ function(install_obs_pdb ttype target)
 	else()
 		obs_debug_copy_helper(${target} "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/bin/${_bit_suffix}")
 
-		if(DEFINED ENV{obsInstallerTempDir})
-			obs_debug_copy_helper(${target} "$ENV{obsInstallerTempDir}/${OBS_EXECUTABLE_DESTINATION}")
+		if(DEFINED ${obsInstallerTempDir})
+			obs_debug_copy_helper(${target} "${obsInstallerTempDir}/${OBS_EXECUTABLE_DESTINATION}")
 		endif()
 
 		install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/pdbs/"
@@ -401,7 +401,7 @@ function(install_obs_core target)
 			"${OBS_OUTPUT_DIR}/$<CONFIGURATION>/bin/${_bit_suffix}$<TARGET_FILE_NAME:${target}>"
 		VERBATIM)
 
-	if(DEFINED ENV{obsInstallerTempDir})
+	if(DEFINED ${obsInstallerTempDir})
 		get_property(target_type TARGET ${target} PROPERTY TYPE)
 		if("${target_type}" STREQUAL "EXECUTABLE")
 			set(tmp_target_dir "${OBS_EXECUTABLE_DESTINATION}")
@@ -412,7 +412,7 @@ function(install_obs_core target)
 		add_custom_command(TARGET ${target} POST_BUILD
 			COMMAND "${CMAKE_COMMAND}" -E copy
 				"$<TARGET_FILE:${target}>"
-				"$ENV{obsInstallerTempDir}/${tmp_target_dir}/$<TARGET_FILE_NAME:${target}>"
+				"${obsInstallerTempDir}/${tmp_target_dir}/$<TARGET_FILE_NAME:${target}>"
 			VERBATIM)
 	endif()
 
@@ -446,11 +446,11 @@ function(install_obs_bin target mode)
 		install(FILES "${bin}"
 			DESTINATION "${OBS_EXECUTABLE_DESTINATION}")
 
-		if(DEFINED ENV{obsInstallerTempDir})
+		if(DEFINED ${obsInstallerTempDir})
 			add_custom_command(TARGET ${target} POST_BUILD
 				COMMAND "${CMAKE_COMMAND}" -E copy
 					"${bin}"
-					"$ENV{obsInstallerTempDir}/${OBS_EXECUTABLE_DESTINATION}/${fname}"
+					"${obsInstallerTempDir}/${OBS_EXECUTABLE_DESTINATION}/${fname}"
 				VERBATIM)
 		endif()
 	endforeach()
@@ -480,7 +480,7 @@ function(install_obs_plugin target)
 	if(DEFINED ENV{obsInstallerTempDir})
 		add_custom_command(TARGET ${target} POST_BUILD
 			COMMAND "${CMAKE_COMMAND}" -E copy
-				"$<TARGET_FILE:${target}>" "$ENV{obsInstallerTempDir}/${OBS_PLUGIN_DESTINATION}/$<TARGET_FILE_NAME:${target}>"
+				"$<TARGET_FILE:${target}>" "${obsInstallerTempDir}/${OBS_PLUGIN_DESTINATION}/$<TARGET_FILE_NAME:${target}>"
 			VERBATIM)
 	endif()
 
@@ -496,10 +496,10 @@ function(install_obs_data target datadir datadest)
 			"${CMAKE_CURRENT_SOURCE_DIR}/${datadir}" "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/data/${datadest}"
 		VERBATIM)
 
-	if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND DEFINED ENV{obsInstallerTempDir})
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND DEFINED ${obsInstallerTempDir})
 		add_custom_command(TARGET ${target} POST_BUILD
 			COMMAND "${CMAKE_COMMAND}" -E copy_directory
-				"${CMAKE_CURRENT_SOURCE_DIR}/${datadir}" "$ENV{obsInstallerTempDir}/${OBS_DATA_DESTINATION}/${datadest}"
+				"${CMAKE_CURRENT_SOURCE_DIR}/${datadir}" "${obsInstallerTempDir}/${OBS_DATA_DESTINATION}/${datadest}"
 			VERBATIM)
 	endif()
 endfunction()
@@ -516,14 +516,14 @@ function(install_obs_data_file target datafile datadest)
 			"${CMAKE_CURRENT_SOURCE_DIR}/${datafile}" "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/data/${datadest}"
 		VERBATIM)
 
-	if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND DEFINED ENV{obsInstallerTempDir})
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND DEFINED ${obsInstallerTempDir})
 		add_custom_command(TARGET ${target} POST_BUILD
 			COMMAND "${CMAKE_COMMAND}" -E make_directory
-				"$ENV{obsInstallerTempDir}/${OBS_DATA_DESTINATION}/${datadest}"
+				"${obsInstallerTempDir}/${OBS_DATA_DESTINATION}/${datadest}"
 			VERBATIM)
 		add_custom_command(TARGET ${target} POST_BUILD
 			COMMAND "${CMAKE_COMMAND}" -E copy
-				"${CMAKE_CURRENT_SOURCE_DIR}/${datafile}" "$ENV{obsInstallerTempDir}/${OBS_DATA_DESTINATION}/${datadest}"
+				"${CMAKE_CURRENT_SOURCE_DIR}/${datafile}" "${obsInstallerTempDir}/${OBS_DATA_DESTINATION}/${datadest}"
 			VERBATIM)
 	endif()
 endfunction()
@@ -538,11 +538,11 @@ function(install_obs_datatarget target datadest)
 			"${OBS_OUTPUT_DIR}/$<CONFIGURATION>/data/${datadest}/$<TARGET_FILE_NAME:${target}>"
 		VERBATIM)
 
-	if(DEFINED ENV{obsInstallerTempDir})
+	if(DEFINED ${obsInstallerTempDir})
 		add_custom_command(TARGET ${target} POST_BUILD
 			COMMAND "${CMAKE_COMMAND}" -E copy
 				"$<TARGET_FILE:${target}>"
-				"$ENV{obsInstallerTempDir}/${OBS_DATA_DESTINATION}/${datadest}/$<TARGET_FILE_NAME:${target}>"
+				"${obsInstallerTempDir}/${OBS_DATA_DESTINATION}/${datadest}/$<TARGET_FILE_NAME:${target}>"
 			VERBATIM)
 	endif()
 endfunction()

--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -358,7 +358,7 @@ function(install_obs_pdb ttype target)
 	if("${ttype}" STREQUAL "PLUGIN")
 		obs_debug_copy_helper(${target} "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/obs-plugins/${_bit_suffix}")
 
-		if(DEFINED ${obsInstallerTempDir})
+		if(DEFINED ENV{obsInstallerTempDir})
 			obs_debug_copy_helper(${target} "${obsInstallerTempDir}/${OBS_PLUGIN_DESTINATION}")
 		endif()
 
@@ -368,7 +368,7 @@ function(install_obs_pdb ttype target)
 	else()
 		obs_debug_copy_helper(${target} "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/bin/${_bit_suffix}")
 
-		if(DEFINED ${obsInstallerTempDir})
+		if(DEFINED ENV{obsInstallerTempDir})
 			obs_debug_copy_helper(${target} "${obsInstallerTempDir}/${OBS_EXECUTABLE_DESTINATION}")
 		endif()
 
@@ -401,7 +401,7 @@ function(install_obs_core target)
 			"${OBS_OUTPUT_DIR}/$<CONFIGURATION>/bin/${_bit_suffix}$<TARGET_FILE_NAME:${target}>"
 		VERBATIM)
 
-	if(DEFINED ${obsInstallerTempDir})
+	if(DEFINED ENV{obsInstallerTempDir})
 		get_property(target_type TARGET ${target} PROPERTY TYPE)
 		if("${target_type}" STREQUAL "EXECUTABLE")
 			set(tmp_target_dir "${OBS_EXECUTABLE_DESTINATION}")
@@ -516,7 +516,7 @@ function(install_obs_data_file target datafile datadest)
 			"${CMAKE_CURRENT_SOURCE_DIR}/${datafile}" "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/data/${datadest}"
 		VERBATIM)
 
-	if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND DEFINED ${obsInstallerTempDir})
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND DEFINED ENV{obsInstallerTempDir})
 		add_custom_command(TARGET ${target} POST_BUILD
 			COMMAND "${CMAKE_COMMAND}" -E make_directory
 				"${obsInstallerTempDir}/${OBS_DATA_DESTINATION}/${datadest}"
@@ -538,7 +538,7 @@ function(install_obs_datatarget target datadest)
 			"${OBS_OUTPUT_DIR}/$<CONFIGURATION>/data/${datadest}/$<TARGET_FILE_NAME:${target}>"
 		VERBATIM)
 
-	if(DEFINED ${obsInstallerTempDir})
+	if(DEFINED ENV{obsInstallerTempDir})
 		add_custom_command(TARGET ${target} POST_BUILD
 			COMMAND "${CMAKE_COMMAND}" -E copy
 				"$<TARGET_FILE:${target}>"


### PR DESCRIPTION
Fixed cmake error on windows on expanding path with backslashes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/obs-studio/69)
<!-- Reviewable:end -->
