### PR TITLE
COBS-51 Crash selecting invalid "Caffeine" entry in docks window

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -7,6 +7,7 @@
 #include "window-basic-main.hpp"
 #include "qt-wrappers.hpp"
 #include "obs-app.hpp"
+#include "ui-config.h"
 #include "url-push-button.hpp"
 
 #include "ui_AutoConfigStartPage.h"
@@ -445,8 +446,10 @@ void AutoConfigStreamPage::on_disconnectAccount_clicked()
 
 	OBSBasic *main = OBSBasic::Get();
 
+#if !CAFFEINE_ENABLED
 	main->auth.reset();
 	auth.reset();
+#endif
 
 	std::string service = QT_TO_UTF8(ui->service->currentText());
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7543,8 +7543,9 @@ QAction *OBSBasic::AddDockWidget(QDockWidget *dock)
 {
 	QAction *action = ui->viewMenuDocks->addAction(dock->windowTitle());
 	action->setCheckable(true);
-	if(dock->isVisible())
+	if(dock->isVisible()) {
 		action->setChecked(true);
+	}	
 	assignDockToggle(dock, action);
 	extraDocks.push_back(dock);
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7543,6 +7543,8 @@ QAction *OBSBasic::AddDockWidget(QDockWidget *dock)
 {
 	QAction *action = ui->viewMenuDocks->addAction(dock->windowTitle());
 	action->setCheckable(true);
+	if(dock->isVisible())
+		action->setChecked(true);
 	assignDockToggle(dock, action);
 	extraDocks.push_back(dock);
 
@@ -7561,6 +7563,16 @@ QAction *OBSBasic::AddDockWidget(QDockWidget *dock)
 	}
 
 	return action;
+}
+
+void OBSBasic::RemoveCaffeineDockWidget(QDockWidget *dock)
+{
+	for (auto &it: ui->viewMenuDocks->actions()) {
+		if(it->text() == dock->windowTitle()) {
+			ui->viewMenuDocks->removeAction(it);
+			return;
+		}
+	}
 }
 
 OBSBasic *OBSBasic::Get()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -787,6 +787,7 @@ public:
 	void CreateFiltersWindow(obs_source_t *source);
 
 	QAction *AddDockWidget(QDockWidget *dock);
+	void RemoveCaffeineDockWidget(QDockWidget *dock);
 
 	static OBSBasic *Get();
 

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -571,9 +571,12 @@ void OBSBasicSettings::on_disconnectAccount_clicked()
 	if (button == QMessageBox::No) {
 		return;
 	}
-
+	
+    // Remove the auth here if caffeine account is not associated
+#if !CAFFEINE_ENABLED
 	main->auth.reset();
 	auth.reset();
+#endif
 
 	std::string service = QT_TO_UTF8(ui->service->currentText());
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -3550,9 +3550,17 @@ bool OBSBasicSettings::QueryChanges()
 	if (button == QMessageBox::Cancel) {
 		return false;
 	} else if (button == QMessageBox::Yes) {
+		// If Caffeine account was linked and disconnected reset the auth here.
+#if CAFFEINE_ENABLED
+		if (ui->connectAccount2->isVisible())
+		{
+			main->auth.reset();
+			auth.reset();
+		}
+#endif
 		SaveSettings();
 	} else {
-		LoadSettings(true);
+		LoadSettings(true);		
 #ifdef _WIN32
 		if (toggleAero)
 			SetAeroEnabled(!aeroWasDisabled);

--- a/UI/window-caffeine.cpp
+++ b/UI/window-caffeine.cpp
@@ -75,8 +75,8 @@ CaffeineInfoPanel::CaffeineInfoPanel(CaffeineAuth *owner,
 
 CaffeineInfoPanel::~CaffeineInfoPanel()
 {
-	// TODO: Remove the Panel from OBS again?
-	OBSBasic::Get()->removeDockWidget(this);
+	// Remove the Panel from OBS 
+	OBSBasic::Get()->RemoveCaffeineDockWidget(this);
 }
 
 std::string CaffeineInfoPanel::getTitle()


### PR DESCRIPTION
Fixed following bugs:
1.  COBS-66 Caffeine Dock unlisted when opening saved account and
2. COBS-51 Crash selecting invalid "Caffeine" entry in docks window

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/obs-studio/72)
<!-- Reviewable:end -->
