### PR TITLE
COBS-77 [COBS] Inaccurate error message is displayed when attempting …

### DIFF
--- a/UI/ui-validation.cpp
+++ b/UI/ui-validation.cpp
@@ -1,5 +1,6 @@
 #include "ui-validation.hpp"
 
+#include "ui-config.h"
 #include <obs.hpp>
 #include <QString>
 #include <QMessageBox>
@@ -75,7 +76,13 @@ UIValidation::StreamSettingsConfirmation(QWidget *parent, OBSService service)
 		return StreamSettingsAction::ContinueStream;
 
 	QString msg;
-
+#if CAFFEINE_ENABLED
+	if (hasStreamUrl) {
+		return StreamSettingsAction::ContinueStream;
+	} else {
+		msg = QTStr("Basic.Settings.Stream.MissingUrl");
+	}
+#else
 	if (!hasStreamUrl && !hasStreamKey) {
 		msg = QTStr("Basic.Settings.Stream.MissingUrlAndApiKey");
 	} else if (!hasStreamKey) {
@@ -83,6 +90,7 @@ UIValidation::StreamSettingsConfirmation(QWidget *parent, OBSService service)
 	} else {
 		msg = QTStr("Basic.Settings.Stream.MissingUrl");
 	}
+#endif
 
 	QMessageBox messageBox(parent);
 	messageBox.setWindowTitle(

--- a/plugins/rtmp-services/rtmp-common.c
+++ b/plugins/rtmp-services/rtmp-common.c
@@ -262,11 +262,15 @@ static json_t *open_services_file(void)
 	char *file;
 	json_t *root = NULL;
 
+	// Don't use the file from user config.
+	// Temporary fix until we land caffeine service in OBS mainline.
+	/*
 	file = obs_module_config_path("services.json");
 	if (file) {
 		root = open_json_file(file);
 		bfree(file);
 	}
+	*/
 
 	if (!root) {
 		file = obs_module_file("services.json");


### PR DESCRIPTION
…to ‘Start Streaming’ without being connected to a Caffeine account

Has the Fix for COBS-77
Also fixed the "Caffeine" service not listed 