### PR TITLE
COBS-66 Caffeine dock is unlisted when opening COBS with a saved account

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - name: 'Install prerequisites (Homebrew)'
         shell: bash
         run: |
-          brew update
+          brew update --preinstall 
           brew bundle --file ./CI/scripts/macos/Brewfile
       - name: 'Install prerequisite: Pre-built dependencies'
         shell: bash

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -446,10 +446,11 @@ void AutoConfigStreamPage::on_disconnectAccount_clicked()
 
 	OBSBasic *main = OBSBasic::Get();
 
-#if !CAFFEINE_ENABLED
-	main->auth.reset();
-	auth.reset();
-#endif
+	// Remove the auth here if caffeine account is not associated
+	if (ui->service->currentText() != "Caffeine") {
+		main->auth.reset();
+		auth.reset();
+	}
 
 	std::string service = QT_TO_UTF8(ui->service->currentText());
 

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -602,10 +602,10 @@ void OBSBasicSettings::on_disconnectAccount_clicked()
 	}
 
 	// Remove the auth here if caffeine account is not associated
-#if !CAFFEINE_ENABLED
-	main->auth.reset();
-	auth.reset();
-#endif
+	if (ui->service->currentText() != "Caffeine") {
+		main->auth.reset();
+		auth.reset();
+	}
 
 	std::string service = QT_TO_UTF8(ui->service->currentText());
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -3622,6 +3622,12 @@ void OBSBasicSettings::on_buttonBox_clicked(QAbstractButton *button)
 
 	if (val == QDialogButtonBox::ApplyRole ||
 	    val == QDialogButtonBox::AcceptRole) {
+#if CAFFEINE_ENABLED
+		if (ui->connectAccount2->isVisible() && main->auth) {
+			main->auth.reset();
+			auth.reset();
+		}
+#endif
 		SaveSettings();
 		ClearChanged();
 	}


### PR DESCRIPTION
- Mac CI builds were taking a long time so fixed that 
To verify if this fixes the problem : 
There are multiple UI States to save the changes in Settings (when connecting/disconnecting Caffeine account ) and should follow following which changing Settings: 

  1. **Ok button** - Should work same as Apply and should save the changes
  2. **Cancel Button**- Discard the changes
  3. **Apply** - Apply the changes
  4. **Close** the Settings Dialog Window with ❌  - Should open up the Message Box Dialog which prompts the user to save the unsaved changes
     - Yes -> save the changes ,
     - No - Discard changes and
     - Cancel - closes the Messages Box dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/obs-studio/86)
<!-- Reviewable:end -->
