### PR TITLE
COBS-116 Caffeine account username is no longer visible in Settings->…

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -986,17 +986,6 @@
                </property>
               </spacer>
              </item>
-             <item row="2" column="1">
-              <layout class="QHBoxLayout" name="horizontalLayout_30">
-               <item>
-                <widget class="QLabel" name="authSignedInAs">
-                 <property name="text">
-                  <string>TextLabel</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
             </layout>
            </widget>
            <widget class="QWidget" name="streamKeyPage">
@@ -1283,6 +1272,26 @@
               <widget class="QLabel" name="enforceSettingsLabel">
                <property name="text">
                 <string notr="true"/>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="authSignedInAsLabel">
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <property name="text">
+                <string>Basic.Settings.Stream.Custom.SignedInAs</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLabel" name="authSignedInAs">
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <property name="text">
+                <string>SomeUser</string>
                </property>
               </widget>
              </item>

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -41,7 +41,7 @@ void OBSBasicSettings::InitStreamPage()
 	ui->disconnectAccount->setVisible(false);
 	ui->bandwidthTestEnable->setVisible(false);
 	ui->authSignedInAs->setVisible(false);
-	//ui->authSignedInAsLabel->setVisible(false);
+	ui->authSignedInAsLabel->setVisible(false);
 	ui->twitchAddonDropdown->setVisible(false);
 	ui->twitchAddonLabel->setVisible(false);
 
@@ -156,12 +156,9 @@ void OBSBasicSettings::LoadStream1Settings()
 #if CAFFEINE_ENABLED
 		if (username && username[0]) {
 			lastSignedInAs = username;
-			//ui->authSignedInAsLabel->setVisible(true);
+			ui->authSignedInAsLabel->setVisible(true);
 			ui->authSignedInAs->setVisible(true);
 			ui->authSignedInAs->setText(QT_UTF8(username));
-		} else {
-			//ui->authSignedInAsLabel->setVisible(false);
-			ui->authSignedInAs->setVisible(false);
 		}
 #endif
 	}
@@ -433,12 +430,12 @@ void OBSBasicSettings::on_service_currentIndexChanged(int)
 	bool isCaffeine = service == "Caffeine";
 	ui->authSignedInAs->setVisible(authenticated && isCaffeine);
 	ui->authSignedInAs->setText(lastSignedInAs);
+	ui->authSignedInAsLabel->setVisible(authenticated && isCaffeine);
 #endif
 	ui->connectAccount->setVisible(can_auth && !authenticated);
 	ui->disconnectAccount->setVisible(can_auth && authenticated);
 	ui->connectAccount2->setVisible(can_auth && !authenticated);
-#else
-	ui->connectAccount2->setVisible(false);
+
 #endif
 
 	ui->useAuth->setVisible(custom);
@@ -569,7 +566,7 @@ void OBSBasicSettings::OnOAuthStreamKeyConnected()
 		if (std::string(a->service()) == "Caffeine") {
 			auto caffeine = dynamic_cast<CaffeineAuth *>(a);
 			lastSignedInAs = caffeine->GetUsername().c_str();
-			//ui->authSignedInAsLabel->setVisible(true);
+			ui->authSignedInAsLabel->setVisible(true);
 			ui->authSignedInAs->setVisible(true);
 			ui->authSignedInAs->setText(lastSignedInAs);
 		}
@@ -656,10 +653,16 @@ void OBSBasicSettings::on_disconnectAccount_clicked()
 	ui->disconnectAccount->setVisible(false);
 	ui->bandwidthTestEnable->setVisible(false);
 	ui->authSignedInAs->setVisible(false);
-	//ui->authSignedInAsLabel->setVisible(false);#
+	ui->authSignedInAsLabel->setVisible(false);
 	ui->twitchAddonDropdown->setVisible(false);
 	ui->twitchAddonLabel->setVisible(false);
 	ui->key->setText("");
+
+// Hide stream keys for Caffeine we do not support it.
+#if CAFFEINE_ENABLED
+	ui->streamKeyWidget->setVisible(false);
+	ui->streamKeyLabel->setVisible(false);
+#endif
 }
 
 void OBSBasicSettings::on_useStreamKey_clicked()

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -29,6 +29,7 @@
 #include <obs.hpp>
 
 #include "auth-base.hpp"
+#include "ui-config.h"
 
 class OBSBasic;
 class QAbstractButton;


### PR DESCRIPTION
…Stream screen
1. Added username 
2. Hidden the stream key since we do not support it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/obs-studio/90)
<!-- Reviewable:end -->
