### PR TITLE
Fix ex bad access

### DIFF
--- a/plugins/caffeine/caffeine-output.cpp
+++ b/plugins/caffeine/caffeine-output.cpp
@@ -645,8 +645,10 @@ static void caffeine_raw_video(void *data, struct video_data *frame)
 			       total_bytes, width, height, timestampMicros);
 	}
 
-	context->frames_tracker->caffeine_add_frame(frame->timestamp,
-						    send_frame);
+	if (context->frames_tracker != nullptr) {
+		context->frames_tracker->caffeine_add_frame(frame->timestamp,
+							    send_frame);
+	}
 
 #ifdef USE_SAMPLE_LOG
 	uint64_t func_complete_timestamp_ns =


### PR DESCRIPTION
handled bad access when deleted the CaffeineFrameTracker on stopping the stream but video thread was still using it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/obs-studio/103)
<!-- Reviewable:end -->
